### PR TITLE
Allow @xml:base to hold the URN for editions

### DIFF
--- a/pages/guidelines.md
+++ b/pages/guidelines.md
@@ -175,9 +175,9 @@ There are three recommendations :
 
 1. If the text is epidoc, the convention is to supply the URN in the following xpath : `TEI/text/body/div[@type="edition" or @type="translation"]/@n` 
 2. If the text is normal TEI, the convention is to supply the URN the following xpath : `TEI/text/body/@n`
-3. For normal TEI, it is also possible to supply the URN as the value of an `@xml:base` attribute; most often, the attribute will be found at `text`, but it can be appended to other elements as well; in any case, elements which have `@xml:base` will be considered editions of an individual work:
-`TEI/text/@xml:base` (in a collection of poems, for example)
-`TEI/text[@xml:base]/div[2]/div/@xml:base` (an individual poem from the second part of the collection)
+3. For normal TEI, it is also possible to supply the URN as the value of an `@xml:base` attribute (most often, the attribute will be found at `text`, but it can be appended to other elements as well); elements which have `@xml:base` will be considered editions of individual works:
+`TEI/text/@xml:base` (contains the URN for a collection of poems, for example), 
+`TEI/text[@xml:base]/div[2]/div/@xml:base` (contains the URN for an individual poem from the second part of the collection)
 
 The same node should have an `xml:lang` attribute stating the language of the text.
 

--- a/pages/guidelines.md
+++ b/pages/guidelines.md
@@ -171,10 +171,13 @@ Instead of relying on edition and translation TEI files or building a general in
 
 ### URN Information
 
-There are two different recommendations :
+There are three recommendations :
 
 1. If the text is epidoc, the convention is to supply the URN in the following xpath : `TEI/text/body/div[@type="edition" or @type="translation"]/@n` 
 2. If the text is normal TEI, the convention is to supply the URN the following xpath : `TEI/text/body/@n`
+3. For normal TEI, it is also possible to supply the URN as the value of an `@xml:base` attribute; most often, the attribute will be found at `text`, but it can be appended to other elements as well; in any case, elements which have `@xml:base` will be considered editions of an individual work:
+`TEI/text/@xml:base` (in a collection of poems, for example)
+`TEI/text[@xml:base]/div[2]/div/@xml:base` (an individual poem from the second part of the collection)
 
 The same node should have an `xml:lang` attribute stating the language of the text.
 

--- a/pages/guidelines.md
+++ b/pages/guidelines.md
@@ -175,9 +175,8 @@ There are three recommendations :
 
 1. If the text is epidoc, the convention is to supply the URN in the following xpath : `TEI/text/body/div[@type="edition" or @type="translation"]/@n` 
 2. If the text is normal TEI, the convention is to supply the URN the following xpath : `TEI/text/body/@n`
-3. For normal TEI, it is also possible to supply the URN as the value of an `@xml:base` attribute (most often, the attribute will be found at `text`, but it can be appended to other elements as well); elements which have `@xml:base` will be considered editions of individual works:
-`TEI/text/@xml:base` (contains the URN for a collection of poems, for example), 
-`TEI/text[@xml:base]/div[2]/div/@xml:base` (contains the URN for an individual poem from the second part of the collection)
+3. For normal TEI, it is also possible to supply the URN as the value of an [@xml:base](http://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-att.global.html) attribute in the following xpath: 
+`TEI/text/@xml:base`
 
 The same node should have an `xml:lang` attribute stating the language of the text.
 


### PR DESCRIPTION
According to the issue [14](https://github.com/Capitains/Capitains.github.io/issues/14), the Guidelines should allow the URN to be found in the `@xml:base` attribute. This attribute will be most often appended to the `text` element. When found elsewhere, it will signify an individual work which is part of a larger work; for example, a poem as part of a collection of poems.